### PR TITLE
feat: Add check_infra_miri in BUILD.gn

### DIFF
--- a/infra/BUILD.gn
+++ b/infra/BUILD.gn
@@ -20,6 +20,11 @@ group("check_infra") {
   deps = [ ":run_infra_unittest" ]
 }
 
+group("check_infra_by_miri") {
+  testonly = true
+  deps = [ ":infra_miri_test($host_miri_toolchain)" ]
+}
+
 shared_deps = [
   "//external/cfg-if/v1.0.0:cfg_if",
   "//external/memchr/v2.7.4:memchr",
@@ -30,6 +35,11 @@ build_rust("blueos_infra") {
   crate_type = "rlib"
   sources = [ "src/lib.rs" ]
   edition = "2021"
+  deps = shared_deps
+}
+
+miri_test("infra_miri_test") {
+  crate = "src/lib.rs"
   deps = shared_deps
 }
 


### PR DESCRIPTION
Description: support for miri test of infra unittest

Reason: integrate miri

Issue: NA

fix: support extern crate use in unittest when running miri

Change-Id: Ic0566d850e6f2afd2445602776de64805b1ed9e0

add conditional compile flag and annotation

Change-Id: I30850623cbcd83e65aa340150f9cc7f9e58de3f9

exchange extern crate order in tinyarc.rs according to dependency relationship

Change-Id: I9c39bff802bc0c61f1b38d249a21ca31bdb2d9ec

comment add host_miri toolchain

Change-Id: Icc821c073cc864792ef0811c38bbc7e466b24d0a

remove spin extern crate (unittest don't need it anymore)

Change-Id: I1d5b1d9e3631fb1973fede75f9dc57e8141d7efd