### PR TITLE
feat: Add check_infra_miri in BUILD.gn

### DIFF
--- a/infra/BUILD.gn
+++ b/infra/BUILD.gn
@@ -20,6 +20,11 @@ group("check_infra") {
   deps = [ ":run_infra_unittest" ]
 }
 
+group("check_infra_by_miri") {
+  testonly = true
+  deps = [ ":infra_miri_test" ]
+}
+
 shared_deps = [
   "//external/cfg-if/v1.0.0:cfg_if",
   "//external/memchr/v2.7.4:memchr",
@@ -31,6 +36,21 @@ build_rust("blueos_infra") {
   sources = [ "src/lib.rs" ]
   edition = "2021"
   deps = shared_deps
+}
+
+miri_test("infra_miri_test") {
+  crate = "src/lib.rs"
+
+  deps = shared_deps  # build direct and indirect dependencies via gn
+                      # toolchain(host_miri), but build infra via command in
+                      # run_miri.py
+
+  # test_name = "bench_insert_and_detach_1_std"   # optional
+  extra_miri_flags = [
+    # "-Zmiri-tree-borrows", # use tree borrow model
+    # "-Zmiri-preemption-rate=0.01", # controls how often Miri forces a thread context switch during scheduling.
+    # more miri flags...
+  ]
 }
 
 build_rust("infra_unittest") {


### PR DESCRIPTION
Description: support for miri test of infra unittest

Reason: integrate miri

Issue: NA

fix: support extern crate use in unittest when running miri

Change-Id: Ic0566d850e6f2afd2445602776de64805b1ed9e0

add conditional compile flag and annotation

Change-Id: I30850623cbcd83e65aa340150f9cc7f9e58de3f9

exchange extern crate order in tinyarc.rs according to dependency relationship

Change-Id: I9c39bff802bc0c61f1b38d249a21ca31bdb2d9ec

comment add host_miri toolchain

Change-Id: Icc821c073cc864792ef0811c38bbc7e466b24d0a

remove spin extern crate (unittest don't need it anymore)

Change-Id: I1d5b1d9e3631fb1973fede75f9dc57e8141d7efd

use fork toolchain repo prebuilt rust for now

Change-Id: I7c9768688b42e4e6cbcacfbafb7bc09651a58296

remove yml changes, yml changes should be in another branch and pr

Change-Id: I90f099af13f6f4a2930db9f618d00c43b44bb79e